### PR TITLE
Update status codes link to V2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Speech optimization is a communication enhancement tool usable by ⬡-Drones. As
 
 A ⬡-Drone can convert a short, three digit Speech Optimzation code into a complete Speech Optimization message.
 
-A [full list of Speech Optimization codes](https://www.hexcorp.net/drone-status-codes) can be found on the official HexCorp website.
+A [full list of Speech Optimization codes](https://www.hexcorp.net/drone-status-codes-v2) can be found on the official HexCorp website.
 
 Examples:
 


### PR DESCRIPTION
Update the link to the full list of Speech Optimization codes to point to the V2 list of status codes.

(It doesn't know why Github's diff tool claims line 301 was also changed. It might be fine?)